### PR TITLE
added tini for init management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV HTTP_PORT=8080
 ENV HTTPS_PORT=8443
 ENV LAS2PEER_PORT=9011
 
-RUN apk add --update bash xmlstarlet mysql-client apache-ant && rm -f /var/cache/apk/*
+RUN apk add --update bash xmlstarlet mysql-client apache-ant tini && rm -f /var/cache/apk/*
 RUN addgroup -g 1000 -S las2peer && \
     adduser -u 1000 -S las2peer -G las2peer
 
@@ -18,4 +18,4 @@ RUN ant jar
 EXPOSE $HTTP_PORT
 EXPOSE $HTTPS_PORT
 EXPOSE $LAS2PEER_PORT
-ENTRYPOINT ["/src/docker-entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--" "/src/docker-entrypoint.sh"]


### PR DESCRIPTION
After ~ 3 days of running, the success-modeling container runs out of memory (2Gb provided).

[pool-10-thread-1] ERROR org.web3j.protocol.core.filters.Filter - Error sending request
java.lang.OutOfMemoryError: Java heap space

Possibly related, was nearby in the logs:

WARNING: A connection to http://las2peer-ethnet:8545/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);

see the following for details:
- https://github.com/docker-library/openjdk/issues/76
- http://www.programmersought.com/article/454192941/
- https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/

without running some sort of init process, we cannot create a heapdump of java to see where the memory leak occurs.