### PR TITLE
prevent service invocation after it has failed

### DIFF
--- a/app/src/main/java/i5/las2peer/services/mobsos/successModeling/MonitoringDataProvisionService.java
+++ b/app/src/main/java/i5/las2peer/services/mobsos/successModeling/MonitoringDataProvisionService.java
@@ -512,6 +512,8 @@ public class MonitoringDataProvisionService extends RESTService {
     } catch (ServiceInvocationException e) {
       System.out.println("ServiceInvocationException:" + e.getMessage());
       e.printStackTrace();
+      System.out.println("Aborting database key check...");
+      return;
     }
     QVConnector.SQLDatabaseType dbType;
     if (this.databaseType == SQLDatabaseType.DB2) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 core.version=1.2.2
 service.name=i5.las2peer.services.mobsos.successModeling
 service.class=MonitoringDataProvisionService
-service.version=1.2.1
+service.version=1.2.2
 java.version=17
 
 las2peer_user1.name=alice


### PR DESCRIPTION
This version introduces a fix that prevents adding a new database key if the query visualization service cannot be reached